### PR TITLE
HTML options on fields

### DIFF
--- a/lib/formeze.rb
+++ b/lib/formeze.rb
@@ -60,6 +60,24 @@ module Formeze
       @options.fetch(:label) { Formeze.translate(name, :scope => [:formeze, :labels], :default => Label.new(name)) }
     end
 
+    def type
+      return if multiline? or multiple?
+      @options.fetch(:type) { "text" }
+    end
+
+    def placeholder
+      return if multiline? or multiple?
+      @options.fetch(:placeholder) { "" }
+    end
+
+    def rows
+      @options.fetch(:rows) { 10 }
+    end
+
+    def cols
+      @options.fetch(:cols) { 50 }
+    end
+
     def required?
       @options.fetch(:required) { true }
     end


### PR DESCRIPTION
Would it be possible to include some new options on fields that relate to the final HTML without compromising Formeze's design goals?

I wrote a quick blog post outlining how I've been using Formeze recently:

http://robm.me.uk/2013/07/24/outputting-html-with-formeze

Basically, I add a couple of new properties to fields (see pull request), allowing me to do something like:

```
field :email, maxlength: 255, type: 'email', placeholder: 'e.g. bob@example.com'
```

…which then means, when I come to outputting the form, I can just iterate over `@form.fields` and instantly know what HTML to output. (In this case, `<input type="text" name="email" maxlength="255" placeholder="e.g. bob@example.com">`.)

Does this fit with the ethos of Formeze?
