### PR TITLE
Adds :commit to the list of keys to silently ignore.

### DIFF
--- a/lib/formeze.rb
+++ b/lib/formeze.rb
@@ -262,7 +262,7 @@ module Formeze
       end
 
       if defined?(Rails)
-        %w(utf8 authenticity_token).each do |key|
+        %w(utf8 authenticity_token commit).each do |key|
           form_data.delete(key)
         end
       end

--- a/spec/formeze_spec.rb
+++ b/spec/formeze_spec.rb
@@ -925,10 +925,11 @@ describe 'FormWithField on Rails' do
   end
 
   describe 'parse method' do
-    it 'silently ignores the utf8 and authenticity_token parameters' do
-      @form.parse('utf8=%E2%9C%93&authenticity_token=5RMc3sPZdR%2BZz4onNS8NfK&title=Test')
+    it 'silently ignores the utf8, commit and authenticity_token parameters' do
+      @form.parse('utf8=%E2%9C%93&authenticity_token=5RMc3sPZdR%2BZz4onNS8NfK&title=Test&commit=Create')
       @form.wont_respond_to(:utf8)
       @form.wont_respond_to(:authenticity_token)
+      @form.wont_respond_to(:commit)
       @form.to_hash.must_equal({:title => 'Test'})
     end
   end


### PR DESCRIPTION
Added `:commit` key to the list of silently ignored parameters, as it is part of the `request` when using Rails and Form helpers to build a form, example: https://gist.github.com/antillas21/214061007c8b4c01a609
